### PR TITLE
fix(indexation): Balise meta en double

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,8 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Devfest Lille 2017</title>
-    <meta name="description" content="Site Web du Devfest Lille 2017">
-    <meta name="description"
-          content="Rejoignez nous pour une journée de conférences, de code labs, d'échanges sur les sujets du Web, du Mobile, du Cloud, des technologies Google et de leur utilisation par les acteurs locaux.">
-    <meta name="google-site-verification" content="_Zig9aZBBUBvmLnQkgXRj6faeJPA_StKfdG7zFsvy_E"/>
-
+    <meta name="description" content="Site du Devfest Lille 2017! Rejoignez-nous pour une journée de conférences et de codelabs pour échanger sur le Web, le Mobile, le Cloud, l'IOT et leur usage par les acteurs locaux.">
+    
     <link rel="icon" href="/images/favicon.ico">
 
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
C'est la première balise meta qui était prise en compte, et indiquée comme trop courte par les webmaster tools.
J'ai aussi ajouté dans les webmaster tools le site en http, comme demandé.

Et dernier point, j'ai enlevé le google-site-verification, tu n'en as plus besoin une fois que ça a été validé.